### PR TITLE
Update the meeting times

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ The schedule is fairly static:
 Time (PDT - **UTC/Z** - CET) | Topic | +Hangout
 :------------------------: | :---: | :------:
 11:30PDT **18:30Z** 19:30CET | Apps on IPFS, electron | [Video Room](https://plus.google.com/hangouts/_/grdn26fpdroghn5wa56mhpxz34a)
-12:00PDT **19:00Z** 20:00CET | infrastructure | [Video Room](https://plus.google.com/hangouts/_/g6irrqkylecjoo2k7e7wzkkkgua)
-12:30PDT **19:30Z** 20:30CET | node-ipfs | [Video Room](https://plus.google.com/hangouts/_/gyafa4mpgz7g6jntijoxshfe3ma)
-13:00PDT **20:00Z** 21:00CET | go-ipfs | [Video Room](https://plus.google.com/hangouts/_/g4hc3dnpdvwsklyfd2sxhkwbgqa)
-13:30PDT **20:30Z** 21:30CET | testing + ci | [Video Room](https://plus.google.com/hangouts/_/gwn656w2cihn7lekdarfzhaquea)
-14:00PDT **21:00Z** 22:00CET | protocol + specs | [Video Room](https://plus.google.com/hangouts/_/gxvjk6v6xrc64hcs44phm4c2qaa)
-14:30PDT **21:30Z** 22:30CET | bitswap ml | [Video Room](https://plus.google.com/hangouts/_/grcpjefkp4fv4zqz3xe4ty3mbea)
+12:15PDT **19:15Z** 20:15CET | infrastructure | [Video Room](https://plus.google.com/hangouts/_/g6irrqkylecjoo2k7e7wzkkkgua)
+13:00PDT **20:00Z** 21:00CET | libp2p | [Video Room](https://plus.google.com/hangouts/_/ipfslibp2p7g6jntijoxshfe3m2)
+13:45PDT **20:45Z** 21:45CET | node-ipfs | [Video Room](https://plus.google.com/hangouts/_/gyafa4mpgz7g6jntijoxshfe3ma)
+14:30PDT **21:30Z** 22:30CET | go-ipfs | [Video Room](https://plus.google.com/hangouts/_/g4hc3dnpdvwsklyfd2sxhkwbgqa)
+15:15PDT **22:15Z** 23:15CET | testing + ci | [Video Room](https://plus.google.com/hangouts/_/gwn656w2cihn7lekdarfzhaquea)
+16:00PDT **23:00Z** 00:00CET | protocol + specs | [Video Room](https://plus.google.com/hangouts/_/gxvjk6v6xrc64hcs44phm4c2qaa)
+16:45PDT **23:45Z** 00:45CET | bitswap ml | [Video Room](https://plus.google.com/hangouts/_/grcpjefkp4fv4zqz3xe4ty3mbea)
 
 - Data Structures -- [Video Room](https://plus.google.com/hangouts/_/g7slan3ecrylra7robofp53p6ia)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The **Sprint Planning** meeting happens semi-synchronously. Some of it is synchr
 
 #### Stage 1: Sprint Cap
 
-> ##### Starts at {10:00 PT, 17:00 UTC, 18:00 CET}
+> ##### Starts at {10:00 PDT, 17:00 UTC, 18:00 CET}
 
 **How: This takes place semi-synchronously on IRC.** (This used to happen over a Google Hangout, but it wasted a lot of time to keep >10 people synchronized while people gave individual updates that not everyone was interested in. IRC has been working ok.)
 
@@ -66,6 +66,8 @@ Time (PDT - **UTC/Z** - CET) | Topic | +Hangout
 14:30PDT **21:00Z** 22:30CET | protocol + specs | [Video Room](https://plus.google.com/hangouts/_/gxvjk6v6xrc64hcs44phm4c2qaa)
 15:00PDT **21:30Z** 23:00CET | bitswap ml | [Video Room](https://plus.google.com/hangouts/_/grcpjefkp4fv4zqz3xe4ty3mbea)
 15:30PDT **22:00Z** 23:30CET | Data Structures | [Video Room](https://plus.google.com/hangouts/_/g7slan3ecrylra7robofp53p6ia)
+
+You can add these meeting times to your Calendar app by adding our [community calendar](https://calendar.google.com/calendar/embed?src=ipfs.io_eal36ugu5e75s207gfjcu0ae84@group.calendar.google.com&ctz=America/New_York)
 
 #### Stage 3: Sprint Allocation
 

--- a/README.md
+++ b/README.md
@@ -57,16 +57,15 @@ The schedule is fairly static:
 
 Time (PDT - **UTC/Z** - CET) | Topic | +Hangout
 :------------------------: | :---: | :------:
-11:30PDT **18:30Z** 19:30CET | Apps on IPFS, electron | [Video Room](https://plus.google.com/hangouts/_/grdn26fpdroghn5wa56mhpxz34a)
-12:15PDT **19:15Z** 20:15CET | infrastructure | [Video Room](https://plus.google.com/hangouts/_/g6irrqkylecjoo2k7e7wzkkkgua)
-13:00PDT **20:00Z** 21:00CET | libp2p | [Video Room](https://plus.google.com/hangouts/_/ipfslibp2p7g6jntijoxshfe3m2)
-13:45PDT **20:45Z** 21:45CET | node-ipfs | [Video Room](https://plus.google.com/hangouts/_/gyafa4mpgz7g6jntijoxshfe3ma)
-14:30PDT **21:30Z** 22:30CET | go-ipfs | [Video Room](https://plus.google.com/hangouts/_/g4hc3dnpdvwsklyfd2sxhkwbgqa)
-15:15PDT **22:15Z** 23:15CET | testing + ci | [Video Room](https://plus.google.com/hangouts/_/gwn656w2cihn7lekdarfzhaquea)
-16:00PDT **23:00Z** 00:00CET | protocol + specs | [Video Room](https://plus.google.com/hangouts/_/gxvjk6v6xrc64hcs44phm4c2qaa)
-16:45PDT **23:45Z** 00:45CET | bitswap ml | [Video Room](https://plus.google.com/hangouts/_/grcpjefkp4fv4zqz3xe4ty3mbea)
-
-- Data Structures -- [Video Room](https://plus.google.com/hangouts/_/g7slan3ecrylra7robofp53p6ia)
+11:30PDT **18:00Z** 19:30CET | Apps on IPFS | [Video Room](https://plus.google.com/hangouts/_/grdn26fpdroghn5wa56mhpxz34a)
+12:00PDT **18:30Z** 20:00CET | infrastructure | [Video Room](https://plus.google.com/hangouts/_/g6irrqkylecjoo2k7e7wzkkkgua)
+12:30PDT **19:00Z** 20:30CET | libp2p | [Video Room](https://plus.google.com/hangouts/_/ipfslibp2p7g6jntijoxshfe3m2)
+13:00PDT **19:30Z** 21:00CET | node-ipfs | [Video Room](https://plus.google.com/hangouts/_/gyafa4mpgz7g6jntijoxshfe3ma)
+13:30PDT **20:00Z** 21:30CET | go-ipfs | [Video Room](https://plus.google.com/hangouts/_/g4hc3dnpdvwsklyfd2sxhkwbgqa)
+14:00PDT **20:30Z** 22:00CET | testing + ci | [Video Room](https://plus.google.com/hangouts/_/gwn656w2cihn7lekdarfzhaquea)
+14:30PDT **21:00Z** 22:30CET | protocol + specs | [Video Room](https://plus.google.com/hangouts/_/gxvjk6v6xrc64hcs44phm4c2qaa)
+15:00PDT **21:30Z** 23:00CET | bitswap ml | [Video Room](https://plus.google.com/hangouts/_/grcpjefkp4fv4zqz3xe4ty3mbea)
+15:30PDT **22:00Z** 23:30CET | Data Structures -- [Video Room](https://plus.google.com/hangouts/_/g7slan3ecrylra7robofp53p6ia)
 
 #### Stage 3: Sprint Allocation
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Time (PDT - **UTC/Z** - CET) | Topic | +Hangout
 14:00PDT **20:30Z** 22:00CET | testing + ci | [Video Room](https://plus.google.com/hangouts/_/gwn656w2cihn7lekdarfzhaquea)
 14:30PDT **21:00Z** 22:30CET | protocol + specs | [Video Room](https://plus.google.com/hangouts/_/gxvjk6v6xrc64hcs44phm4c2qaa)
 15:00PDT **21:30Z** 23:00CET | bitswap ml | [Video Room](https://plus.google.com/hangouts/_/grcpjefkp4fv4zqz3xe4ty3mbea)
-15:30PDT **22:00Z** 23:30CET | Data Structures -- [Video Room](https://plus.google.com/hangouts/_/g7slan3ecrylra7robofp53p6ia)
+15:30PDT **22:00Z** 23:30CET | Data Structures | [Video Room](https://plus.google.com/hangouts/_/g7slan3ecrylra7robofp53p6ia)
 
 #### Stage 3: Sprint Allocation
 


### PR DESCRIPTION
As discussed in the previous Monday, we are:

- Increasing the meeting time from 30 mins to 45 minutes.
- Be very diligent about respecting the allocated time slot for each discussion, so that other people don't have their meetings dragged by the accumulative delay from the previous meetings
- Add a libp2p focused meeting

Once this PR gets merged, lets add these meetings to our community calendar