### PR TITLE
Use username instead of real name

### DIFF
--- a/sprint-issue-template.md
+++ b/sprint-issue-template.md
@@ -8,14 +8,14 @@
 
 Please take notes in a separate pad, if you can, and link it here.
 
-Endeavour         | Lead                | Time (PDT - **UTC/Z** - CET) | Pad
-:---------------: | :-----------------: | :--------------------------: | :----:
-sync              | Rich Littauer       | 9:00pDT **17:00Z** 18:00CET  | IRC: #ipfs on Freenode
-apps on ipfs      | Friedel Ziegelmayer | 10:30PDT **18:30Z** 19:30CET | https://public.etherpad-mozilla.org/p/ipfs-__Date__-apps-on-ipfs
-infrastructure    | Lars Gierth         | 11:00PDT **19:00Z** 20:00CET | https://public.etherpad-mozilla.org/p/ipfs-__Date__-infrastructure
-libp2p            | David Dias          | 11:30PDT **19:30Z** 20:30CET | https://public.etherpad-mozilla.org/p/ipfs-__Date__-libp2p
-js-ipfs           | David Dias          | 12:00PDT **20:00Z** 21:00CET | https://public.etherpad-mozilla.org/p/ipfs-__Date__-js-ipfs
-go-ipfs           | Jeromy Johnson      | 12:30PDT **20:30Z** 21:30CET | https://public.etherpad-mozilla.org/p/ipfs-__Date__-go-ipfs
+Endeavour         | Lead            | Time (PDT - **UTC/Z** - CET) | Pad
+:---------------: | :-------------: | :--------------------------: | :----:
+sync              | @RichardLitt    | 9:00pDT **17:00Z** 18:00CET  | IRC: #ipfs on Freenode
+apps on ipfs      | @dignifiedquire | 10:30PDT **18:30Z** 19:30CET | https://public.etherpad-mozilla.org/p/ipfs-__Date__-apps-on-ipfs
+infrastructure    | @lgierth        | 11:00PDT **19:00Z** 20:00CET | https://public.etherpad-mozilla.org/p/ipfs-__Date__-infrastructure
+libp2p            | @diasdavid      | 11:30PDT **19:30Z** 20:30CET | https://public.etherpad-mozilla.org/p/ipfs-__Date__-libp2p
+js-ipfs           | @diasdavid      | 12:00PDT **20:00Z** 21:00CET | https://public.etherpad-mozilla.org/p/ipfs-__Date__-js-ipfs
+go-ipfs           | @whyrusleeping  | 12:30PDT **20:30Z** 21:30CET | https://public.etherpad-mozilla.org/p/ipfs-__Date__-go-ipfs
 
 Please add the Agenda to the Pad before the endeavour sprint starts.
 


### PR DESCRIPTION
This notifies the leaders when the sprint is created, and makes it easier for newcomers to see who is who in the comments in the sprint.