### PR TITLE
Create sprint-calls-prep guide

### DIFF
--- a/admin-guides/sprint-calls-prep.md
+++ b/admin-guides/sprint-calls-prep.md
@@ -1,7 +1,7 @@
 # Prep for Sprint Calls
 
 ## Who does this Prep
-
+The moderator for the upcoming week's sprint calls
 
 ## Steps to Take
 

--- a/admin-guides/sprint-calls-prep.md
+++ b/admin-guides/sprint-calls-prep.md
@@ -1,0 +1,19 @@
+# Prep for Sprint Calls
+
+## Who does this Prep
+
+
+## Steps to Take
+
+**Before the Call**
+
+1. Set up the sprint issue, using the [sprint issue template](https://github.com/ipfs/pm/blob/master/templates/sprint-issue.md), on Wednesday of the preceding week so people can start proposing agenda items
+1. Set up the hangouts links and post them on the sprint issue ticket
+1. Solicit IRC for agenda items
+
+**During the Calls**
+1. Act as moderator/facilitator on the all-hands call
+
+**After the Call**
+
+1. Close the previous week's sprint issue

--- a/admin-guides/sprint-calls-prep.md
+++ b/admin-guides/sprint-calls-prep.md
@@ -1,19 +1,29 @@
 # Prep for Sprint Calls
 
 ## Who does this Prep
-The moderator for the upcoming week's sprint calls
+
+The moderator for the upcoming week's sprint calls.
 
 ## Steps to Take
 
-**Before the Call**
+**Advanced preparation**
 
-1. Set up the sprint issue, using the [sprint issue template](https://github.com/ipfs/pm/blob/master/templates/sprint-issue.md), on Wednesday of the preceding week so people can start proposing agenda items
-1. Set up the hangouts links and post them on the sprint issue ticket
-1. Solicit IRC for agenda items
+On Wednesday of the preceding week:
+- Set up the sprint issue, using the [sprint issue template](https://github.com/ipfs/pm/blob/master/templates/sprint-issue.md), so people can start proposing agenda items.
+- Set up the Etherpad links, so that people can start proposing agenda items for each call.
+
+By Friday of the preceding week:
+- Set up the call times for the following Monday, posted in the Sprint issue.
+- Adjust the calendar times to match the Sprint issue.
+
+**Before the Call**
+1. Launch a Hangouts On Air, and share the links on IRC using the [irc-hangout-announcement](https://github.com/ipfs/pm/blob/master/templates/irc-hangout-announcement.md) template.
+1. Solicit IRC for agenda items.
 
 **During the Calls**
 1. Act as moderator/facilitator on the all-hands call
 
 **After the Call**
 
-1. Close the previous week's sprint issue
+1. Close the previous week's sprint issue.
+1. Follow up with discussion leads making sure they have PRed the notes to the ipfs/pm repo.


### PR DESCRIPTION
@RichardLitt let's put together a guide for this.  I think it will hit a cross section of stuff you've been doing and stuff I've been doing.  We should also discuss _who_ should be responsible for these tasks. A lot of them have been falling to you in the catch-all sprint admin role.  Is that how it should work?