### PR TITLE
All-hands calls use a timezone based roll call

### DIFF
--- a/admin-guides/timezone-rollcall.md
+++ b/admin-guides/timezone-rollcall.md
@@ -7,17 +7,26 @@ Use this script to do a roll call by timezones.
 ### Current Team
 This covers the time zones that we currently get participants from.
 
- - UTC +2 Eastern Europe 
- - UTC +1 Central Europe 
- - UTC
- - UTC -5 US Eastern timezone
- - UTC -6 US Central timezone
- - UTC -7 US Mountain timezone
- - UTC -8 US Pacific timezone  
- - ... and anyone who was missed or who dialed in during roll call
+> - UTC +2 Eastern Europe 
+- UTC +1 Central Europe 
+- UTC
+- UTC -5 US Eastern timezone
+- UTC -6 US Central timezone
+- UTC -7 US Mountain timezone
+- UTC -8 US Pacific timezone  
+- ... and anyone who was missed or who dialed in during roll call
 
  
 ### More Time Zones
 
-If you need to include more time zones, add them to the list as necessary or simply count from UTC +11 down to UTC -11. When you're done, check for  any people who were missed or who dialed in during roll call.
+**If you need to include people who are from other spots in the world, add their time zones to the list on the fly as necessary.**  If we regularly get participants from a particular time zone, submit a PR adding it to the default script. 
+
+**If you need to cover the whole world**, simply count from UTC +11 down to UTC -11. When you're done, check for  any people who were missed or who dialed in during roll call.
+
+> - UTC +11
+- UTC +10
+- ...
+- UTC -10
+- UTC -11
+- ... and anyone who was missed or who dialed in during roll call
  

--- a/admin-guides/timezone-rollcall.md
+++ b/admin-guides/timezone-rollcall.md
@@ -1,0 +1,23 @@
+# Timezone-based Roll Call
+
+Use this script to do a roll call by timezones.
+
+![Standard world Time Zones](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e8/Standard_World_Time_Zones.png/800px-Standard_World_Time_Zones.png)
+
+### Current Team
+This covers the time zones that we currently get participants from.
+
+ - UTC +2 Eastern Europe 
+ - UTC +1 Central Europe 
+ - UTC
+ - UTC -5 US Eastern timezone
+ - UTC -6 US Central timezone
+ - UTC -7 US Mountain timezone
+ - UTC -8 US Pacific timezone  
+ - ... and anyone who was missed or who dialed in during roll call
+
+ 
+### More Time Zones
+
+If you need to include more time zones, add them to the list as necessary or simply count from UTC +11 down to UTC -11. When you're done, check for  any people who were missed or who dialed in during roll call.
+ 

--- a/admin-guides/timezone-rollcall.md
+++ b/admin-guides/timezone-rollcall.md
@@ -21,12 +21,12 @@ This covers the time zones that we currently get participants from.
 
 **If you need to include people who are from other spots in the world, add their time zones to the list on the fly as necessary.**  If we regularly get participants from a particular time zone, submit a PR adding it to the default script. 
 
-**If you need to cover the whole world**, simply count from UTC +11 down to UTC -11. When you're done, check for  any people who were missed or who dialed in during roll call.
+**If you need to cover the whole world**, simply count from UTC -11 up to UTC +11. When you're done, check for  any people who were missed or who dialed in during roll call.
 
-> - UTC +11
-- UTC +10
-- ...
+> - UTC -11
 - UTC -10
-- UTC -11
+- ...
+- UTC +10
+- UTC +11
 - ... and anyone who was missed or who dialed in during roll call
  

--- a/templates/agenda-for-all-hands-call.md
+++ b/templates/agenda-for-all-hands-call.md
@@ -7,7 +7,9 @@
 
 
 ## Agenda
-1. Roll call - see [timezone-based roll call](../admin-guides/timezone-rollcall.md) guide - _ensure notetaker is present_
+_ensure notetaker is present before you begin_  
+
+1. Roll call - see [timezone-based roll call](../admin-guides/timezone-rollcall.md) guide
 1. Call for additional agenda items (moderator)
 1. Moderator/notetaker for next time:
  * Moderator: TBD

--- a/templates/agenda-for-all-hands-call.md
+++ b/templates/agenda-for-all-hands-call.md
@@ -7,16 +7,7 @@
 
 
 ## Agenda
-1. Roll call by [timezone](https://en.wikipedia.org/wiki/Time_zone#/media/File:Standard_World_Time_Zones.png) per following order - _ensure notetaker is present_
- - UTC +2 Eastern Europe 
- - UTC +1 Central Europe 
- - UTC
- - UTC -3 & -4 (Brazil, Argentina, Chile, etc.)
- - UTC -5 US Eastern timezone
- - UTC -6 US Central timezone
- - UTC -7 US Mountain timezone
- - UTC -8 US Pacific timezone
- - folks who were missed or who dialed in during roll call
+1. Roll call - see [timezone-based roll call](../admin-guides/timezone-rollcall.md) guide - _ensure notetaker is present_
 1. Call for additional agenda items (moderator)
 1. Moderator/notetaker for next time:
  * Moderator: TBD

--- a/templates/agenda-for-all-hands-call.md
+++ b/templates/agenda-for-all-hands-call.md
@@ -7,7 +7,16 @@
 
 
 ## Agenda
-1. Roll call by alphabetical order (moderator)
+1. Roll call by [timezone](https://en.wikipedia.org/wiki/Time_zone#/media/File:Standard_World_Time_Zones.png) per following order - _ensure notetaker is present_
+ - UTC +2 Eastern Europe 
+ - UTC +1 Central Europe 
+ - UTC
+ - UTC -3 & -4 (Brazil, Argentina, Chile, etc.)
+ - UTC -5 US Eastern timezone
+ - UTC -6 US Central timezone
+ - UTC -7 US Mountain timezone
+ - UTC -8 US Pacific timezone
+ - folks who were missed or who dialed in during roll call
 1. Call for additional agenda items (moderator)
 1. Moderator/notetaker for next time:
  * Moderator: TBD


### PR DESCRIPTION
Option: I could split the script for the timezone roll call into its own file, so it won't be repeated in the notes every week. 