### PR TITLE
(WIP) Generated PM Roadmap

### DIFF
--- a/ORG-ROADMAP.md
+++ b/ORG-ROADMAP.md
@@ -1,0 +1,110 @@
+# IPFS - Roadmap
+
+This document describes the current status and the upcoming milestones of the IPFS project.
+
+*Updated: Tue, 06 Sep 2016 20:44:05 GMT*
+
+#### Milestone Summary
+
+| Status | Milestone | Goals | ETA |
+| :---: | :--- | :---: | :---: |
+| 🚀 | **[js-go interoperability](#js-go-interoperability)** | ![Progress](http://progressed.io/bar/0) | Fri Aug 26 2016 |
+| 🚀 | **[ipfs-0.4.3-rc4](#ipfs-0.4.3-rc4)** | ![Progress](http://progressed.io/bar/88) | Tue Aug 30 2016 |
+| 🚀 | **[ipfs 0.4.4](#ipfs-0.4.4)** | ![Progress](http://progressed.io/bar/16) | Tue Sep 06 2016 |
+| 🚀 | **[ipld integration](#ipld-integration)** | ![Progress](http://progressed.io/bar/0) | Fri Sep 09 2016 |
+| 🚀 | **[Integrate Orbit with uPort](#integrate-orbit-with-uport)** | ![Progress](http://progressed.io/bar/50) | Thu Sep 15 2016 |
+| 🚀 | **[Implement New Project Management Model](#implement-new-project-management-model)** | ![Progress](http://progressed.io/bar/25) | Thu Sep 22 2016 |
+| 🚀 | **[First Preview of Distributed Web Primer](#first-preview-of-distributed-web-primer)** | ![Progress](http://progressed.io/bar/0) | Thu Sep 22 2016 |
+| 🚀 | **[Improve Orbit's and orbit-db's documentation and developer experience](#improve-orbit's-and-orbit-db's-documentation-and-developer-experience)** | ![Progress](http://progressed.io/bar/34) | Fri Sep 23 2016 |
+| 🚀 | **[Orbit with IPFS Pubsub](#orbit-with-ipfs-pubsub)** | ![Progress](http://progressed.io/bar/0) | Tue Sep 27 2016 |
+| 🚀 | **[First Organization Roadmap](#first-organization-roadmap)** | ![Progress](http://progressed.io/bar/0) | Fri Sep 30 2016 |
+| 🚀 | **[IPFS Core API](#ipfs-core-api)** | ![Progress](http://progressed.io/bar/0) | Sat Oct 08 2016 |
+| ⭐ | **[Fix Orbit](#fix-orbit)** | ![Progress](http://progressed.io/bar/100) | Thu Aug 11 2016 |
+
+## Milestones and Goals
+
+#### js-go interoperability
+
+> Tasks that need to be completed for the go and javascript implementations to be able to communicate.
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**0 / 1** goals completed **(0%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Fri Aug 26 2016**
+
+
+#### ipfs-0.4.3-rc4
+
+> 
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**16 / 18** goals completed **(88%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Tue Aug 30 2016**
+
+
+#### ipfs 0.4.4
+
+> Version 0.4.4 of go-ipfs
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**1 / 6** goals completed **(16%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Tue Sep 06 2016**
+
+
+#### ipld integration
+
+> integration of the ipld data format into go-ipfs
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**0 / 1** goals completed **(0%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Fri Sep 09 2016**
+
+
+#### Integrate Orbit with uPort
+
+> Use uPort Identity for Orbit's users.
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**1 / 2** goals completed **(50%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Thu Sep 15 2016**
+
+
+#### Implement New Project Management Model
+
+> This milestone will be done when the new PM model is stable and ratified by all the IPFS-related projects and when all Major IPFS-related Project Roadmaps conform to that New PM Model. See issues status at https://waffle.io/ipfs/pm?milestone=Implement%20New%20Project%20Management%20Model This work will allow us to then assemble our first Organization Roadmap. We want to have this done before the Q4 Quarterly Meeting so that we can use this new PM model during that meeting.
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**3 / 12** goals completed **(25%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Thu Sep 22 2016**
+
+
+#### First Preview of Distributed Web Primer
+
+> Release a version of the Distributed Web Primer that covers core IPFS tutorials.  This will not be the complete Primer -- some chapters will be excluded -- but it will cover the most important tutorials. See status board at https://waffle.io/ipfs/pm?milestone=First%20Preview%20of%20Distributed%20Web%20Primer
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**0 / 1** goals completed **(0%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Thu Sep 22 2016**
+
+
+#### Improve Orbit's and orbit-db's documentation and developer experience
+
+> Write better documentation, write more examples, cleanup and refactor code where needed.
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**8 / 23** goals completed **(34%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Fri Sep 23 2016**
+
+
+#### Orbit with IPFS Pubsub
+
+> Integrate with IPFS Pubsub (if available)
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**0 / 1** goals completed **(0%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Tue Sep 27 2016**
+
+
+#### First Organization Roadmap
+
+> The organization roadmap gathers the roadmaps and milestones of all our projects into a consolidated view.  
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**0 / 1** goals completed **(0%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Fri Sep 30 2016**
+
+
+#### IPFS Core API
+
+> In the past months we've established a core set of commands that IPFS nodes can support. The JS implementation (js-ipfs and js-ipfs-api) is already compliant, and this milestone is all about making the Go implementation (go-ipfs and go-ipfs-api) compliant. Check out https://github.com/ipfs/interface-ipfs-core
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**0 / 6** goals completed **(0%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Sat Oct 08 2016**
+
+
+#### Fix Orbit
+
+> Fix all the things that got broken in the past couple of months and bring together a version that uses both IPFS go and JS implementations.
+
+⭐ &nbsp;**CLOSED** &nbsp;&nbsp;📉 &nbsp;&nbsp;**6 / 6** goals completed **(100%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Thu Aug 11 2016**
+
+
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,73 @@
+# IPFS Project Management - Roadmap
+
+This document describes the current status and the upcoming milestones of the IPFS Project Management efforts.
+
+*Updated: Tue, 06 Sep 2016 20:27:15 GMT*
+
+## IPFS PM
+
+#### Milestone Summary
+
+| Status | Milestone | Goals | ETA |
+| :---: | :--- | :---: | :---: |
+| 🚀 | **[Implement New Project Management Model](#implement-new-project-management-model)** | 3 / 12 | Thu Sep 22 2016 |
+| 🚀 | **[First Organization Roadmap](#first-organization-roadmap)** | 0 / 1 | Fri Sep 30 2016 |
+
+#### Implement New Project Management Model
+
+> This milestone will be done when the new PM model is stable and ratified by all the IPFS-related projects and when all Major IPFS-related Project Roadmaps conform to that New PM Model. See issues status at https://waffle.io/ipfs/pm?milestone=Implement%20New%20Project%20Management%20Model This work will allow us to then assemble our first Organization Roadmap. We want to have this done before the Q4 Quarterly Meeting so that we can use this new PM model during that meeting.
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**3 / 12** goals completed **(25%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Thu Sep 22 2016**
+
+| Status | Goal | Labels | Repository |
+| :---: | :--- | --- | --- |
+| ❌ | [Address "Definition of Ready" in the PM Document's discussion of Pipelines](https://github.com/ipfs/pm/issues/169) |`ready`| <a href=https://github.com/ipfs/pm>ipfs/pm</a> |
+| ❌ | [Clarify the headings "Units of Work" and "Structures"](https://github.com/ipfs/pm/issues/168) |`needs review`, `ready`| <a href=https://github.com/ipfs/pm>ipfs/pm</a> |
+| ❌ | [Add Term: Status Board](https://github.com/ipfs/pm/issues/167) |`ready`| <a href=https://github.com/ipfs/pm>ipfs/pm</a> |
+| ❌ | [Frame Milestones as crossover point between the timeline view (Roadmap) and the pipeline view (Status Board) of your Goals](https://github.com/ipfs/pm/issues/166) |`needs review`, `ready`| <a href=https://github.com/ipfs/pm>ipfs/pm</a> |
+| ❌ | [Provide a clear definition of "Backlog" with guidelines for using it](https://github.com/ipfs/pm/issues/165) |`in progress`, `needs review`| <a href=https://github.com/ipfs/pm>ipfs/pm</a> |
+| ❌ | [Clearly define Product Owner, Project Lead, and Project Manager ](https://github.com/ipfs/pm/issues/164) |`in progress`, `needs review`| <a href=https://github.com/ipfs/pm>ipfs/pm</a> |
+| ✔ | [Pm doc draft 2](https://github.com/ipfs/pm/pull/155) | | <a href=https://github.com/ipfs/pm>ipfs/pm</a> |
+| ❌ | [Define options for the Mechanics of Tracking Project Milestones](https://github.com/ipfs/pm/issues/154) |`in progress`| <a href=https://github.com/ipfs/pm>ipfs/pm</a> |
+| ❌ | [Test out the PM Process on go-ipfs Project](https://github.com/ipfs/pm/issues/153) |`in progress`| <a href=https://github.com/ipfs/pm>ipfs/pm</a> |
+| ✔ | [Overhaul README](https://github.com/ipfs/pm/pull/136) | | <a href=https://github.com/ipfs/pm>ipfs/pm</a> |
+| ✔ | [(WIP) Project Management Process document](https://github.com/ipfs/pm/pull/131) | | <a href=https://github.com/ipfs/pm>ipfs/pm</a> |
+| ❌ | [Project Management Process discussion](https://github.com/ipfs/pm/issues/125) |`in progress`| <a href=https://github.com/ipfs/pm>ipfs/pm</a> |
+
+
+#### First Organization Roadmap
+
+> The organization roadmap gathers the roadmaps and milestones of all our projects into a consolidated view.  
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**0 / 1** goals completed **(0%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Fri Sep 30 2016**
+
+| Status | Goal | Labels | Repository |
+| :---: | :--- | --- | --- |
+| ❌ | [Identify which Projects Need Roadmaps and Who Maintains those Roadmaps](https://github.com/ipfs/pm/issues/135) |`ready`| <a href=https://github.com/ipfs/pm>ipfs/pm</a> |
+
+
+## IPFS Community
+
+#### Milestone Summary
+
+| Status | Milestone | Goals | ETA |
+| :---: | :--- | :---: | :---: |
+| 🚀 | **[First Preview of Distributed Web Primer](#first-preview-of-distributed-web-primer)** | 0 / 1 | Thu Sep 22 2016 |
+
+#### First Preview of Distributed Web Primer
+
+> Release a version of the Distributed Web Primer that covers core IPFS tutorials.  This will not be the complete Primer -- some chapters will be excluded -- but it will cover the most important tutorials. See status board at https://waffle.io/ipfs/pm?milestone=First%20Preview%20of%20Distributed%20Web%20Primer
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**0 / 1** goals completed **(0%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Thu Sep 22 2016**
+
+| Status | Goal | Labels | Repository |
+| :---: | :--- | --- | --- |
+| ❌ | [Tutorial: Files on IPFS](https://github.com/ipfs/community/issues/163) |`ready`| <a href=https://github.com/ipfs/community>ipfs/community</a> |
+
+
+## IPFS Website, Blog, Newsletter, etc.
+
+#### Milestone Summary
+
+| Status | Milestone | Goals | ETA |
+| :---: | :--- | :---: | :---: |

--- a/org-roadmap.conf.js
+++ b/org-roadmap.conf.js
@@ -1,0 +1,45 @@
+'use strict'
+
+module.exports = {
+  // Name of the organization or project this roadmap is generated for
+  organization: 'IPFS',
+
+  // Include open and closed milestones where due date is after milestonesStartDate
+  milestonesStartDate: '2016-08-01T00:00:00Z', // ISO formatted timestamp
+
+  // Include open and closed milestones where due date is before milestonesEndDate
+  milestonesEndDate: '2016-11-01T00:00:00Z', // ISO formatted timestamp
+
+  // Github repository to open open a Pull Request with the generated roadmap
+  targetRepo: "ipfs/pm",
+
+  // List of projects that this roadmap covers
+  projects: [
+    {
+      name: "IPFS - Consolidated",
+      repos: [
+        "ipfs/ipfs",
+        "ipfs/pm",
+        "ipfs/community",
+        "ipfs/blog",
+        "ipfs/newsletter",
+        "ipfs/website",
+        "ipfs/go-ipfs",
+        "ipfs/js-ipfs",
+        "ipfs/js-ipfs-api",
+        "ipfs/interface-ipfs-core",
+        "haadcode/orbit",
+        "haadcode/orbit-db",
+        "haadcode/orbit-db-store",
+        "haadcode/orbit-db-kvstore",
+        "haadcode/orbit-db-eventstore",
+        "haadcode/orbit-db-feedstore",
+        "haadcode/orbit-db-counterstore",
+        "haadcode/orbit-crypto",
+        "haadcode/ipfs-log",
+        "haadcode/ipfs-post",
+        "haadcode/crdts",
+      ],
+    }
+  ]
+}

--- a/roadmap-generator.conf.js
+++ b/roadmap-generator.conf.js
@@ -1,0 +1,40 @@
+'use strict'
+
+module.exports = {
+  // Name of the organization or project this roadmap is generated for
+  organization: 'IPFS Project Management',
+
+  // Include open and closed milestones where due date is after milestonesStartDate
+  milestonesStartDate: '2016-08-01T00:00:00Z', // ISO formatted timestamp
+
+  // Include open and closed milestones where due date is before milestonesEndDate
+  milestonesEndDate: '2016-11-01T00:00:00Z', // ISO formatted timestamp
+
+  // Github repository to open open a Pull Request with the generated roadmap
+  targetRepo: "ipfs/pm",
+
+  // List of projects that this roadmap covers
+  projects: [
+    {
+      name: "IPFS PM",
+      repos: [
+        "ipfs/ipfs",
+        "ipfs/pm"
+      ]
+    },
+    {
+      name: "IPFS Community",
+      repos: [
+        "ipfs/community",
+      ]
+    },
+    {
+      name: "IPFS Website, Blog, Newsletter, etc.",
+      repos: [
+        "ipfs/blog",
+        "ipfs/newsletter",
+        "ipfs/website"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a config file for generating a roadmap for IPFS PM work using haadcode/roadmap-generator. I also added a sample Organization Roadmap too.  KEEP IN MIND that this generated Org Roadmap is incomplete because it only recognizes GH milestones as milestones, _so any project that's using GH labels or GH tickets to represent milestones will be missed from this Org Roadmap._

@haadcode this generator is awesome.

@em-ly @RichardLitt how do you feel about using this roadmap as a frame for figuring out where we need to create Milestones in order to make everyone's PM and community-related work visible?
- ORG-ROADMAP.md: https://github.com/ipfs/pm/blob/623fdf1f54547ba7dcd697bed20fe8cdc9d1b1e9/ORG-ROADMAP.md
- PM ROADMAP.md: https://github.com/ipfs/pm/blob/623fdf1f54547ba7dcd697bed20fe8cdc9d1b1e9/ROADMAP.md

Configs for the generator (which tells it which repositories and timeframes to include):
- Org Roadmap Config: https://github.com/ipfs/pm/blob/623fdf1f54547ba7dcd697bed20fe8cdc9d1b1e9/org-roadmap.conf.js
- PM Roadmap Config: https://github.com/ipfs/pm/blob/623fdf1f54547ba7dcd697bed20fe8cdc9d1b1e9/roadmap-generator.conf.js

ref #135
