### PR TITLE
Fix go-ipfs notes formatting

### DIFF
--- a/meeting-notes/2016-09-12-go-ipfs.md
+++ b/meeting-notes/2016-09-12-go-ipfs.md
@@ -23,34 +23,33 @@
 **You have 30 minutes for this agenda**, 5 minutes before the meeting ends, consider moving the remaining items to a github discussion thread so that all the other sprint meetings can start in time.
 
 ## Notes
+
 Top Priorities:
- - Made a lot of progress on interop with js-ipfs
- - work on pubsub
-Q: Is pubsub in master?
-A: No, not yet.
+- Made a lot of progress on interop with js-ipfs
+- work on pubsub
+  - Q: Is pubsub in master? A: No, not yet.
 
 Also:
- - Released candidate 4 for version 4.3
- - Working on demos for devcon 2
- - Getting closer to having DHT extracted (\o/)
+- Released candidate 4 for version 4.3
+- Working on demos for devcon 2
+- Getting closer to having DHT extracted (\o/)
 
 Milestones Update (https://github.com/ipfs/go-ipfs/milestones ):
-     - Finished RC Milestone
-    There were changes on both go-ipfs and js-ipfs
-go-ipfs - the docker team was using a priority queue for organizing packets, but wasn't setting priorities on the incoming stream. lead to issues with dropping packets because of not knowing what stream they belonged to.
-js-ipfs - pull stream issue. was hard to figure out how to fix. also, speedy transport was setting random priorities for things with no logic. major time sink.
--  Merged CID (thanks everyone for contributing!)
+- Finished 0.4.3-rc4 Milestone
+  - There were changes on both go-ipfs and js-ipfs
+    - go-ipfs - the docker team was using a priority queue for organizing packets, but wasn't setting priorities on the incoming stream. lead to issues with dropping packets because of not knowing what stream they belonged to.
+    - js-ipfs - pull stream issue. was hard to figure out how to fix. also, speedy transport was setting random priorities for things with no logic. major time sink.
+- Merged CID (thanks everyone for contributing!)
 - @Kubuxu update
 - @lgierth testing websites hosted through IPNS, getting perf metrics later today/tomorrow.
 - Core API update: this is the first part for the API, it doesn't need to be merged but a quick review that it's progressing in the correct direction would be good. Going to get katkinson on API progress.
-- All of this is in the go-ipfs repo to get the ball rolling, when extracting the interface that will be done within each respective project.
+  - All of this is in the go-ipfs repo to get the ball rolling, when extracting the interface that will be done within each respective project.
+  - @diasdavid: @lgierth let's get something integrated with the current IPFS core, we might have to do some publishing before this happens. If it should be ported or if it should be a spec and each interface creates their own documentation for integration. This is a good idea because it helps get things merged quicker - developing the developer interface should be focused on getting this right.
 
- - @diasdavid: @lgierth let's get something integrated with the current IPFS core, we might have to do some publishing before this happens. If it should be ported or if it should be a spec and each interface creates their own documentation for integration. This is a good idea because it helps get things merged quicker - developing the developer interface should be focused on getting this right.
+DEVCON2 help needed
+- @whyrusleeping will start reaching out to people for code review
 
- - @whyrusleeping will start reaching out to people with ready tasks
- - @lgierth 
-
- - PM meeting update
-Going to test out @haadcode's milestones generator to use for meeting management in the future.
+PM meeting update
+- Going to test out @haadcode's milestones generator to use for meeting management in the future.
 
 ##### After sprint meeting is finished, create the respective action items on the Github sprint issue


### PR DESCRIPTION
@em-ly list items need to have correct spacing in front, starting with 0 spaces for the top-level, and adding 2 spaces for each additional level. Otherwise github will make it look all messy :)