### PR TITLE
Remove call title from notes link

### DIFF
--- a/templates/sprint-issue.md
+++ b/templates/sprint-issue.md
@@ -8,10 +8,10 @@ Zoom and Stream links will be updated directly before the calls. Links to them w
 
 Endeavour      | Lead            | Time (PDT - **UTC/Z** - CEST) | Zoom     | Stream     | Pad
 :------------: | :-------------: | :---------------------------: | :------: | :--------: | :----:
-All Hands Call | @flyingzumwalt  | 9:00PDT **16:00Z** 18:00CEST  | [Zoom]() | [Stream]() | [all-hands notes](https://public.etherpad-mozilla.org/p/ipfs-__Date__-all-hands)
-go-ipfs        | @whyrusleeping  | 10:00PDT **17:00Z** 19:00CEST | [Zoom]() | [Stream]() | [go-ipfs notes](https://public.etherpad-mozilla.org/p/ipfs-__Date__-go-ipfs)
-js-ipfs        | @diasdavid      | 10:30PDT **17:30Z** 19:30CEST | [Zoom]() | [Stream]() | [js-ipfs notes](https://public.etherpad-mozilla.org/p/ipfs-__Date__-js-ipfs)
-libp2p         | @diasdavid      | 11:00PDT **18:00Z** 20:00CEST | [Zoom]() | [Stream]() | [libp2p notes](https://public.etherpad-mozilla.org/p/ipfs-__Date__-libp2p)
-IPLD           | @nicola         | 11:30PDT **18:30Z** 20:30CEST | [Zoom]() | [Stream]() | [ipld notes](https://public.etherpad-mozilla.org/p/ipfs-__Date__-ipld)
+All Hands Call | @flyingzumwalt  | 9:00PDT **16:00Z** 18:00CEST  | [Zoom]() | [Stream]() | [notes](https://public.etherpad-mozilla.org/p/ipfs-__Date__-all-hands)
+go-ipfs        | @whyrusleeping  | 10:00PDT **17:00Z** 19:00CEST | [Zoom]() | [Stream]() | [notes](https://public.etherpad-mozilla.org/p/ipfs-__Date__-go-ipfs)
+js-ipfs        | @diasdavid      | 10:30PDT **17:30Z** 19:30CEST | [Zoom]() | [Stream]() | [notes](https://public.etherpad-mozilla.org/p/ipfs-__Date__-js-ipfs)
+libp2p         | @diasdavid      | 11:00PDT **18:00Z** 20:00CEST | [Zoom]() | [Stream]() | [notes](https://public.etherpad-mozilla.org/p/ipfs-__Date__-libp2p)
+IPLD           | @nicola         | 11:30PDT **18:30Z** 20:30CEST | [Zoom]() | [Stream]() | [notes](https://public.etherpad-mozilla.org/p/ipfs-__Date__-ipld)
 
 Please add any agenda items you have to the pad before the project-specific sprint call starts.


### PR DESCRIPTION
This is unnecessary, and means I need to edit the url just a bit more each time there is an edit. I think just saying notes does the job, as it is in a row for each call topic anyway, and as the URL is not opaque itself regarding to which topic it is.

I want review on this because it is not an arbitrary decision; having the notes name in the link may make it easier, and removing it may only affect me. 