### PR TITLE
Remove lead from templates, other edits

### DIFF
--- a/templates/sprint-issue.md
+++ b/templates/sprint-issue.md
@@ -11,18 +11,18 @@ Zoom and Stream links will be updated directly before the calls. Links to them w
 
 ### Monday
 
-Endeavour      | Time (PST - UTC - CET) | Pad
-:------------: | :--------------------: | :----:
-All Hands Call | 9:00 **17:00** 18:00   | [agenda and notes]()
-go-ipfs        | 10:00 **18:00** 19:00  | [agenda and notes]()
-Apps on IPFS   | 10:30 **18:30** 19:30  | [agenda and notes]()
-js-ipfs        | 11:00 **19:00** 20:00  | [agenda and notes]()
-libp2p         | 11:30 **19:30** 20:30  | [agenda and notes]()
+Endeavour      | Lead           | Time (PST - UTC - CET) | Pad
+:------------: | :------------: | :--------------------: | :----:
+All Hands Call | __LEAD__       | 9:00 **17:00** 18:00   | [agenda and notes]()
+go-ipfs        | @whyrusleeping | 10:00 **18:00** 19:00  | [agenda and notes]()
+Apps on IPFS   | @haadcode      | 10:30 **18:30** 19:30  | [agenda and notes]()
+js-ipfs        | @diasdavid     | 11:00 **19:00** 20:00  | [agenda and notes]()
+libp2p         | @diasdavid     | 11:30 **19:30** 20:30  | [agenda and notes]()
 
 ### Friday
 
-Endeavour      | Time (PST - UTC - CET) | Pad
-:------------: | :--------------------: | :----:
-IPLD           | 9:00 **17:00** 18:00   | [agenda and notes]()
+Endeavour      | Lead    | Time (PST - UTC - CET) | Pad
+:------------: | :-----: |:--------------------: | :----:
+IPLD           | @nicola | 9:00 **17:00** 18:00   | [agenda and notes]()
 
 Please add any agenda items you have to the pad before the project-specific sprint call starts.

--- a/templates/sprint-issue.md
+++ b/templates/sprint-issue.md
@@ -9,13 +9,20 @@ Zoom and Stream links will be updated directly before the calls. Links to them w
 **[Zoom link]()**
 **[Stream link]()**
 
-Endeavour      | Lead            | Time (PST - **UTC/Z** - CET) | Pad
-:------------: | :-------------: | :-------------------------: | :----:
-All Hands Call | @flyingzumwalt  | 9:00PST **17:00Z** 18:00CET  | [notes]()
-go-ipfs        | @whyrusleeping  | 10:00PST **18:00Z** 19:00CET | [notes]()
-apps on IPFS   | @haadcode       | 10:30PST **18:30Z** 19:30CET | [notes]()
-js-ipfs        | @diasdavid      | 11:00PST **19:00Z** 20:00CET | [notes]()
-libp2p         | @diasdavid      | 11:30PST **19:30Z** 20:30CET | [notes]()
-IPLD           | @nicola         | 12:00PST **20:00Z** 21:00CET | [notes]()
+### Monday
+
+Endeavour      | Time (PST - UTC - CET) | Pad
+:------------: | :--------------------: | :----:
+All Hands Call | 9:00 **17:00** 18:00   | [agenda and notes]()
+go-ipfs        | 10:00 **18:00** 19:00  | [agenda and notes]()
+Apps on IPFS   | 10:30 **18:30** 19:30  | [agenda and notes]()
+js-ipfs        | 11:00 **19:00** 20:00  | [agenda and notes]()
+libp2p         | 11:30 **19:30** 20:30  | [agenda and notes]()
+
+### Friday
+
+Endeavour      | Time (PST - UTC - CET) | Pad
+:------------: | :--------------------: | :----:
+IPLD           | 9:00 **17:00** 18:00   | [agenda and notes]()
 
 Please add any agenda items you have to the pad before the project-specific sprint call starts.


### PR DESCRIPTION
I think having a lead for each call gives the wrong impression of the scope of each project. For instance, @haadcode isnt the only person who can handle Apps on IPFS. As well, it stops others from jumping in to facilitate these calls. Finally, in at least the All hands call, it rotates, and I think it should in the others. I have removed it in this PR.

I have also removed the extra time zone markings, which are in the column, and removed bold from the UTC timezone (which did not show up in the markdown, anyway), and added the word agenda to the notes to make it clearer what that link points to. Overall, I think this is now a cleaner template for the sprints.

Finally, I moved IPLD to Friday, and added a Monday and a Friday section to make this clearer.