### PR TITLE
docs: fix distributed teams link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We use a loose agile approach, breaking our work into weekly sprints. Here are s
 - You do not have to follow all of the project-specific discusions. They can be very detailed. Only go to ones you want to go to. We post the notes (such as they are) in the sprint issue in this repository afterwards.
 - If you have a topic to discuss or have done work that you want to tell everyone about, propose the agenda item my adding a comment on that week's sprint issue.
 
-You can also find a list of `Distributed Teams` resources on tools, decision making, process, etc, that we have been gathering, reviewing, discussing and experimenting with at [distributed-teams folder](/distributed-teams).
+You can also find a list of `Distributed Teams` resources on tools, decision making, process, etc, that we have been gathering, reviewing, discussing and experimenting with at [distributed-teams page](/DISTRIBUTED_TEAMS.md).
 
 ## Weekly All Hands
 


### PR DESCRIPTION
Commit db0b391484563e0ea7324196cdf785bf325d87f8 has broken the link for
the DISTRIBUTED_TEAMS.md file.