### PR TITLE
simplify template for ALL HANDS

### DIFF
--- a/templates/ALL_HANDS_CALL.md
+++ b/templates/ALL_HANDS_CALL.md
@@ -13,16 +13,7 @@
 
 ## Agenda
 
-<!-- Add topics and/or below this line. Use this format:
-
+<!-- Add topics and/or below this line. --> 
 - <Topic> (<your_name>, <estimated length in mins>)
-
-example:
-- A new release of js-ipfs is coming! (@diasdavid, 2 mins)
-- Demo: PeerPad (@pgte, 4 mins)
-
-The total sum should not exceed 50 mins (10 mins for questions buffer). Topics/Demos that do not get time should be postponed tracked so that a call can be scheduled to go over them.
--->
-
 
 <!-- After each call, it is the responsibility of the notetaker to save the last version of the notes in a file in ipfs/pm/meeting-notes, by opening a branch and submitting a PR. -->

--- a/templates/ALL_HANDS_CALL.md
+++ b/templates/ALL_HANDS_CALL.md
@@ -12,8 +12,14 @@
 - [ ] Call for additional agenda items
 
 ## Agenda
-
-<!-- Add topics and/or below this line. --> 
+_General discussions, decisions, etc._
+<!-- use this format for all topics, demos, etc. that you add to the agenda: -->
 - <Topic> (<your_name>, <estimated length in mins>)
+
+## Demos
+_Show your work!_
+
+## Q&A, Help Wanted
+_Ask questions, get answers. Announce issues that need help, get people to help._
 
 <!-- After each call, it is the responsibility of the notetaker to save the last version of the notes in a file in ipfs/pm/meeting-notes, by opening a branch and submitting a PR. -->


### PR DESCRIPTION
The extra comments, guidance and examples have confused people every week since they were added to the template. The template should be basic and simple. If we want to provide guidance and instructions, we should have that in a separate document, and link to it from the template.