### PR TITLE
Updating ipfs/pm README links to #calendar in community repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This calendar an other IPFS Community calls are tracked on the [IPFS Community C
 
 #### Schedule
 
-The schedule for the sprint discussions for each week is on the corresponding ticket (aka "sprint issue") for that week's sprint. It's also in the [IPFS community calendar](https://calendar.google.com/calendar/embed?src=ipfs.io_eal36ugu5e75s207gfjcu0ae84@group.calendar.google.com&ctz=America/New_York).
+The schedule for the sprint discussions for each week is on the corresponding ticket (aka "sprint issue") for that week's sprint. It's also in the [IPFS community calendar](https://github.com/ipfs/community#calendar).
 
 #### Zoom
 


### PR DESCRIPTION
Updating ipfs/pm README links to #calendar in ipfs/community in order to avoid having to copy around future changes to that external link.
