### PR TITLE
Add all-hands meeting notes 2018-06-04 & 2018-06-11

### DIFF
--- a/meeting-notes/2018-06-04--all-hands.md
+++ b/meeting-notes/2018-06-04--all-hands.md
@@ -1,0 +1,43 @@
+# IPFS All Hands Call 04 June 2018
+
+* **Moderator:** @Mr0grog
+* **Notetaker:** @meiqimichelle
+* **Recording:** https://www.youtube.com/watch?v=i-8Jh_kj_Gw&list=PLuhRWgmPaHtSGRSHdU9dbsukHKlihZZAe
+* **Attendees:**
+    * @Mr0grog
+    * @mkg20001
+    * @b5
+    * @jacobheun
+    * @jaycarpenter
+    * @jonnycrunch
+    * @meiqimichelle
+    * @victorbjelkholm
+    * @vasco-santos
+    * @stebalien
+    * @michellebrous
+    
+
+## Agenda
+
+* go-ipfs DHT fixes have been merged and merging from libp2p has been unblocked (stebalien).
+    * Apparently, publishing IPNS records using a key other than the peer ID key has been broken since 0.4.14.
+        * Well, it works to some older nodes, but for some versions it doesn’t work. Boo.
+        * Jeromy working on a fix, should be in next release, and if we getting it working right, IPNS will be more usable. Yay.
+
+* Question about July dev meetings, how they’re going
+    * There are people organizing logistics, and then there are people developing sessions and content. Request of working group captains: make sure we’ve got great sessions and content planned. There are three repos:
+    * Entry point repo: [https://github.com/ipfs/conf](https://www.google.com/url?q=https://github.com/ipfs/conf&sa=D&ust=1528741252062000)
+    * Propose and discuss sessions here: [https://github.com/ipfs/developer-meetings](https://www.google.com/url?q=https://github.com/ipfs/developer-meetings&sa=D&ust=1528741252062000)
+    * Propose and discuss sessions here: [https://github.com/libp2p/developer-meetings](https://www.google.com/url?q=https://github.com/libp2p/developer-meetings&sa=D&ust=1528741252063000)
+
+
+## Demos
+
+* @vasco-santos - Service Worker Gateway
+
+    * [https://dev.js.ipfs.io](https://www.google.com/url?q=https://dev.js.ipfs.io&sa=D&ust=1528741252063000)
+    * Could we make this into a nice drop-in library? The only requirement is to have assets on IPFS. Is it in a separate repo, or is it….?
+        * No -- you just need to require it, you are ready to use.
+        * Great -- if we provided as browserify bundle, the same way we do with js-ipfs, this would be really beneficial. Adding a build step, packaging it, this would be really useful.
+        * Yes -- it could be a great piece for someone who already has a public IPFS gateway, but this causes some strain on the gateway. The dev could add a small script to the the header to take these parts. Really exciting!
+    * \[David explains service worker in the IPFS context really clearly which we should write down somewhere :) \] Request: have some sort of diagram or explanation as to why this is useful and how it fits in.

--- a/meeting-notes/2018-06-11--all-hands.md
+++ b/meeting-notes/2018-06-11--all-hands.md
@@ -1,0 +1,63 @@
+# **IPFS All Hands Call 11 June 2018**
+
+* **Moderator:** @lidel
+* **Notetaker:** @Mr0grog
+* **Video: NO RECORDING TODAY; nobody with recording permissions is present.**
+* **Attendees:**
+    * *@jacobheun*
+    * *@Mr0grog*
+    * *@mkg20001*
+    * *@stebalien*
+    * *@b5*
+    * *@lidel*
+    * *@jaycarpenter*
+    * *@kumavis*
+
+
+## **Agenda**
+
+* <@djdv> We need to address meeting management
+    * Spending a lot of time at the start of the meeting prepping, this is bad
+    * Would like to end this meeting by talking about next week
+    * Need more to talk about what we’re planning, not just what we’ve done
+    * Need people who are responsible to be here
+    * Trying to make an effort to work this out with Protocol Labs & Community and make this smoother!
+
+* <@Mr0grog> Re-raising [https://github.com/ipfs/pm/issues/636](https://github.com/ipfs/pm/issues/636) (Turn this meeting into scheduled presentations) in case anyone has not seen it.
+    * No scheduled date for this
+    * Would like @flyingzumwalt to to make that clear and put a time-box on it  when he’s back
+
+
+## **Demos**
+
+* PeerPad with libp2p-rendezvous (@mkg20001, ~5min) ([https://rendezvous.mkg20001.io*/](https://rendezvous.mkg20001.io/))
+    * Doesn’t depend on a special server directly but can actually be p2p!
+    * Connect to discover server that provides libp2p circuit relay
+    * Still a proof-of-concept
+    * @Lidel: is this a streamlined version of websocket-star, or totally separate
+        * This is a new thing, based on discovery protocol
+        * Not based on websocket protocol
+        * Entirely based on libp2p; no external libraries!
+    * @Lidel: maybe "rendezvous" name is problematic; it was used for other things before
+        * Proposal for protocol is a PR in the libp2p/specs repo
+        * Protocol developed by vyzo
+    * @Lidel: would be nice to have a paragraph that clearly separates this from websocket-star’s rendezvous server
+    * @mkg20001: Kinda hacky still because you have to create your swarm first; still trying to work around that
+    * @Lidel: we should figure out how to make it more clear and easy to integrate
+    * @mkg20001: will create a PR with my patch for this soon ([https://ipfs.io/ipfs/QmWymxpZf7kHdURCUTuz5SniAAnbsd1yqxnJrETuSfpiY*D](https://ipfs.io/ipfs/QmWymxpZf7kHdURCUTuz5SniAAnbsd1yqxnJrETuSfpiYD))
+    * @lidel: I would expect to see it somewhere around:
+        * [https://github.com/ipfs/js-ipfs/blob/master/src/core/runtime/libp2p-browser.j*s](https://github.com/ipfs/js-ipfs/blob/master/src/core/runtime/libp2p-browser.js)* and*
+        * [https://github.com/ipfs/js-ipfs/blob/master/src/core/runtime/config-browser.j*s](https://github.com/ipfs/js-ipfs/blob/master/src/core/runtime/config-browser.js)
+        * @mkg20001: Not sure that is totally feasible at the moment; let’s move this conversation to an issue
+    * @stebalien: I would prefer not to call it rendezvous because this isn’t actually rendezvous. This is announce/discovery
+        * @mkg20001: was intended to replace a never-used part of libp2p-circuit, wanted to make it a broader discovery protocol all things can use
+        * @stebalien: my concern is really that the name will prevent people from understanding that (can use it for all kinds of things in all kinds of applications without websocket-star)
+        * @lidel: maybe we should make an issue for bikeshedding on this name and not discuss more here. I think people agree there is room for improvement here.
+        * @mkg20001: issue about renedzvous in peer-pad: https://github.com/ipfs-shipyard/peer-pad/issues/178
+
+* @djdv: I want to start an issue about managing the meetings in ipfs/pm (see first agenda item); I’ll get on that today.
+
+
+## **Q&A, Help Wanted**
+
+*None Today*


### PR DESCRIPTION
Meeting notes for last week were missing from the repo, so adding them along with this week's. Fixes #641.