### PR TITLE
Clarify & update responsibilities for weekly call

### DIFF
--- a/admin-guides/sprint-calls-prep.md
+++ b/admin-guides/sprint-calls-prep.md
@@ -1,26 +1,37 @@
-# Prep for Sprint Calls
+# Prep for Weekly Calls
 
-## Who does this Prep
+## Who is Responsible
 
-Ideally, the lead of each call, or a specific person.
+- Host stays the same for each month.
+- Last week of each month, identify a host for the following month.
+- If the host can't make it some week, they are responsible for delegating to someone and make sure they have permissions at least a day ahead.
 
-## Steps to Take
-
-**Advanced preparation**
+## Host Responsibilities
 
 On Wednesday of the preceding week:
 - Make sure that [node-github-issue-bot](https://github.com/ipfs/node-github-issue-bot) has created the next sprint issue. It should use templates from [here](https://github.com/ipfs/node-github-issue-bot/tree/master/templates). If it breaks, look at [the README in ipfs/infrastructure](https://github.com/ipfs/infrastructure/tree/master/sprintbot).
 - Manually fill out the Notes link with [the templates](https://github.com/ipfs/pm/tree/master/templates). To not do this manually, follow [this issue](https://github.com/ipfs/node-github-issue-bot/issues/8).
 
-By Friday of the preceding week:
-- Adjust the calendar times to match the Sprint issue. To not manually do this, follow [this issue](https://github.com/ipfs/node-github-issue-bot/issues/4).
+#### Before the Call
+1. Make sure agenda is posted beforehand in github (Under current format, ideally a day or more so people can add items before the meeting. Also consider proposed changes in #636.)
+1. Post a notice just prior to and at meeting time on IRC, Twitter, & relevant channels
 
-**Before the Call**  
+#### During the Call
+1. Be there at the start time promptly. You don’t need to moderate, but you have all the rights so you must be there to grant them.
+1. Identify a notetaker. Bot is down as of June 2018, but host can call for volunteers and nudge people who haven't taken notes recently.
+1. Facilitate the call, keeping an eye on time & looking out for raised hands.
 
-1. Launch a Zoom call and share the URL with [@dignifiedquire](https://github.com/dignifiedquire) or [@kubuxu](https://github.com/Kubuxu).
-1. Announce the call in IRC using `sprinthelper: announce`. To do this, manually copy over the name of the call, the number of the issue, the notes URL, the zoom call URL, and the Stream URL (which should be gotten from dig or Kuba). To automate this, close [this issue](https://github.com/ipfs/sprint-helper/issues/17).
-
-**After the Call**
+#### After the Call
 
 1. Close the previous week's sprint issue.
+1. Uploading the recording to YouTube.
 1. Make sure that the Notetaker PRed the notes to `ipfs/pm/meeting_notes`.
+
+## Permissions
+
+The 1Password "IPFS Calls" vault contains credentials for:
+- Zoom to host & record call
+- YouTube to upload recordings
+- Twitter to announce meetings
+
+If you are hosting and need access, ping @flyingzumwalt or @mishmosh.

--- a/admin-guides/sprint-calls-prep.md
+++ b/admin-guides/sprint-calls-prep.md
@@ -15,13 +15,13 @@ On Wednesday of the preceding week:
 #### Before the Call
 
 1. Make sure agenda is posted beforehand in GitHub using the current format (see #647 for an example). Ideally, this should be a day or more early so people can add items before the meeting. (Also consider proposed changes in #636.)
-1. Post a notice just prior to and at the meeting time on IRC (#ipfs & #ipfs-dev), Twitter (@ipfsbot), & relevant channels.
+1. Post a notice just prior to and at the meeting time on IRC (#ipfs & #ipfs-dev) and Twitter (@ipfsbot).
 
 #### During the Call
 
-1. Be on Zoom promptly at the start time. You don’t need to moderate, but you have all the rights so you must be there to grant them.
+1. Be on Zoom promptly at the start time.
 1. Identify a notetaker. The bot that does this is down as of June 2018, but you can call for volunteers and nudge people who haven’t taken notes recently.
-1. Facilitate the call, keeping an eye on time & looking out for raised hands.
+1. Moderate the call: keep time and stack, and facilitate discussion as needed.
 
 #### After the Call
 

--- a/admin-guides/sprint-calls-prep.md
+++ b/admin-guides/sprint-calls-prep.md
@@ -2,9 +2,9 @@
 
 ## Who is Responsible
 
-- Host stays the same for each month.
-- Last week of each month, identify a host for the following month.
-- If the host can't make it some week, they are responsible for delegating to someone and make sure they have permissions at least a day ahead.
+- The host stays the same for each month.
+- On the last week of each month, identify a host for the following month.
+- If the host can’t make it some week, they are responsible for delegating to someone and making sure they have permissions at least a day ahead.
 
 ## Host Responsibilities
 
@@ -13,23 +13,25 @@ On Wednesday of the preceding week:
 - Manually fill out the Notes link with [the templates](https://github.com/ipfs/pm/tree/master/templates). To not do this manually, follow [this issue](https://github.com/ipfs/node-github-issue-bot/issues/8).
 
 #### Before the Call
-1. Make sure agenda is posted beforehand in github (Under current format, ideally a day or more so people can add items before the meeting. Also consider proposed changes in #636.)
-1. Post a notice just prior to and at meeting time on IRC, Twitter, & relevant channels
+
+1. Make sure agenda is posted beforehand in GitHub using the current format (see #647 for an example). Ideally, this should be a day or more early so people can add items before the meeting. (Also consider proposed changes in #636.)
+1. Post a notice just prior to and at the meeting time on IRC (#ipfs & #ipfs-dev), Twitter (@ipfsbot), & relevant channels.
 
 #### During the Call
-1. Be there at the start time promptly. You don’t need to moderate, but you have all the rights so you must be there to grant them.
-1. Identify a notetaker. Bot is down as of June 2018, but host can call for volunteers and nudge people who haven't taken notes recently.
+
+1. Be on Zoom promptly at the start time. You don’t need to moderate, but you have all the rights so you must be there to grant them.
+1. Identify a notetaker. The bot that does this is down as of June 2018, but you can call for volunteers and nudge people who haven’t taken notes recently.
 1. Facilitate the call, keeping an eye on time & looking out for raised hands.
 
 #### After the Call
 
-1. Close the previous week's sprint issue.
-1. Uploading the recording to YouTube.
+1. Close the previous week’s sprint issue.
+1. Upload the recording to YouTube.
 1. Make sure that the Notetaker PRed the notes to `ipfs/pm/meeting_notes`.
 
 ## Permissions
 
-The 1Password "IPFS Calls" vault contains credentials for:
+The 1Password “IPFS Calls” vault contains credentials for:
 - Zoom to host & record call
 - YouTube to upload recordings
 - Twitter to announce meetings

--- a/admin-guides/sprint-calls-prep.md
+++ b/admin-guides/sprint-calls-prep.md
@@ -14,8 +14,9 @@ On Wednesday of the preceding week:
 
 #### Before the Call
 
-1. Make sure agenda is posted beforehand in GitHub using the current format (see #647 for an example). Ideally, this should be a day or more early so people can add items before the meeting. (Also consider proposed changes in #636.)
-1. Post a notice just prior to and at the meeting time on IRC (#ipfs & #ipfs-dev) and Twitter (@ipfsbot).
+1. Make sure the agenda is posted with the GitHub issue beforehand, using the current format (see [#647](https://github.com/ipfs/pm/issues/647) for an example). Ideally, this should be done a day or more in advance, so people can add items before the meeting begins. (Also consider proposed changes in [#636](https://github.com/ipfs/pm/issues/636).)
+1. A few minutes prior to the meeting's start time, post a notice on IRC (#ipfs & #ipfs-dev) and Twitter (@ipfsbot). A second notice should be sent out at the meeting's start time as well.  
+Something along the lines of "IPFS all-hands call is about to start (16UTC) \<link to github issue\>"
 
 #### During the Call
 

--- a/admin-guides/sprint-calls-prep.md
+++ b/admin-guides/sprint-calls-prep.md
@@ -37,4 +37,4 @@ The 1Password “IPFS Calls” vault contains credentials for:
 - YouTube to upload recordings
 - Twitter to announce meetings
 
-If you are hosting and need access, ping @flyingzumwalt or @mishmosh.
+If you are hosting and need access to the vault, ping @flyingzumwalt, @diasdavid, or @mishmosh.


### PR DESCRIPTION
This moves the changes proposed in #644 to the documentation. Additionally, it adds documentation for how someone would get all the permissions to host a call.

It does not attempt to solve #636.