### PR TITLE
Add recording link for 2018-06-18 js dev weekly

### DIFF
--- a/meeting-notes/2018/2018-06-18--js-ipfs-dev-team-weekly.md
+++ b/meeting-notes/2018/2018-06-18--js-ipfs-dev-team-weekly.md
@@ -9,7 +9,7 @@
   - @hugomrdias
   - @vmx
   
-- **Recording:** _add link to recording once it's online_
+- **Recording:** https://www.youtube.com/watch?v=xa0jT9r8Na8
 
 ## Agenda
 


### PR DESCRIPTION
I accidentally merged the meeting notes before this was ready. Adding it now!